### PR TITLE
Add custom converter to genesis_date

### DIFF
--- a/CoinGecko/CoinGecko.csproj
+++ b/CoinGecko/CoinGecko.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
         <IncludeSymbols>True</IncludeSymbols>
-        <PackageVersion>1.3.2</PackageVersion>
+        <PackageVersion>1.5.6</PackageVersion>
         <title>Coin Gecko Async Api</title>
         <Authors>Levent Saatci</Authors>
         <Description>.Net and .Net Standart coin gecko async client for newest Min-API</Description>
@@ -21,7 +21,7 @@
         <PackageReleaseNotes>
             Coin Gecko Api wrapper written in .net standard 2.0 for more information please check the official documentation from https://www.coingecko.com/api/docs/v3
         </PackageReleaseNotes>
-        <Version>1.3.2</Version>
+        <Version>1.5.6</Version>
     </PropertyGroup>
 
     <ItemGroup>

--- a/CoinGecko/Converters/CustomDateTimeConverter.cs
+++ b/CoinGecko/Converters/CustomDateTimeConverter.cs
@@ -1,0 +1,12 @@
+using Newtonsoft.Json.Converters;
+
+namespace CoinGecko.Converters
+{
+    public class CustomDateTimeConverter : IsoDateTimeConverter
+    {
+        public CustomDateTimeConverter(string format)
+        {
+            DateTimeFormat = format;
+        }
+    }
+}

--- a/CoinGecko/Entities/Response/Coins/CoinByIdFullData.cs
+++ b/CoinGecko/Entities/Response/Coins/CoinByIdFullData.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using CoinGecko.Converters;
 using CoinGecko.Entities.Response.Shared;
 using Newtonsoft.Json;
 
@@ -19,6 +20,7 @@ namespace CoinGecko.Entities.Response.Coins
         [JsonProperty("country_origin")] public string CountryOrigin { get; set; }
 
         [JsonProperty("genesis_date", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonConverter(typeof(CustomDateTimeConverter), "yyyy-MM-dd")]
         public DateTimeOffset? GenesisDate { get; set; }
 
         [JsonProperty("market_cap_rank")] public long? MarketCapRank { get; set; }


### PR DESCRIPTION
When making the following call with the default serialiser settings, it is resulting in an exception:
```csharp
await _client.CoinsClient.GetAllCoinDataWithId("stratis", "false", false, true, false, false, false);
```

```
System.Net.Http.HttpRequestException: String '2016-08-09' was not recognized as a valid DateTime.
   at CoinGecko.Clients.BaseApiClient.GetAsync[T](Uri resourceUri)
   at CoinGecko.Clients.CoinsClient.GetAllCoinDataWithId(String id, String localization, Boolean tickers, Boolean marketData, Boolean communityData, Boolean developerData, Boolean sparkline)
```

Using a custom converter to explicitly specify the DateTime format resolves this.