### PR TITLE
GetAllCoinDataWithId - market_data.ath.* can be nullable.

### DIFF
--- a/CoinGecko/Entities/Response/Coins/CoinByIdFullData.cs
+++ b/CoinGecko/Entities/Response/Coins/CoinByIdFullData.cs
@@ -76,7 +76,7 @@ namespace CoinGecko.Entities.Response.Coins
 
     public class CoinByIdMarketData : MarketData
     {
-        [JsonProperty("ath")] public Dictionary<string, decimal> Ath { get; set; }
+        [JsonProperty("ath")] public Dictionary<string, decimal?> Ath { get; set; }
 
         [JsonProperty("ath_change_percentage")]
         public Dictionary<string, decimal> AthChangePercentage { get; set; }


### PR DESCRIPTION
Currently a call to this API with certain cryptos will result in a data type conversion error.  Try `CoinsClient.GetAllCoinDataWithId("chiliz-wormhole")`