### PR TITLE
Fixed type of CirculatingSupply property in MarketOhlcv entity

### DIFF
--- a/CoinGecko/Entities/Response/Coins/MarketOhlcv.cs
+++ b/CoinGecko/Entities/Response/Coins/MarketOhlcv.cs
@@ -21,7 +21,7 @@ namespace CoinGecko.Entities.Response.Coins
         public decimal? MarketCapChangePercentage24H { get; set; }
 
         [JsonProperty("circulating_supply")]
-        public string CirculatingSupply { get; set; }
+        public decimal? CirculatingSupply { get; set; }
 
         [JsonProperty("total_supply")]
         public decimal? TotalSupply { get; set; }


### PR DESCRIPTION
The `circulating_supply` value is returned as a number from the API

Example request: [https://api.coingecko.com/api/v3/coins/markets?vs_currency=eur&ids=bitcoin](https://api.coingecko.com/api/v3/coins/markets?vs_currency=eur&ids=bitcoin)
