### PR TITLE
Added constructor overload to force public api usage

### DIFF
--- a/CoinGecko.Test/BaseTest.cs
+++ b/CoinGecko.Test/BaseTest.cs
@@ -1,0 +1,34 @@
+﻿using CoinGecko.Interfaces;
+using System;
+using System.Net.Http;
+using CoinGecko.Clients;
+using Newtonsoft.Json;
+
+namespace CoinGecko.Test
+{
+	public abstract class TestBase
+	{
+		/// <summary>
+		/// API_KEY used in all requests, for both "Paid" and "Demo" versions
+		/// </summary>
+		private const string _apiKey = "";
+		/// <summary>
+		/// Should be set to true if provided key is for "Demo" subscription
+		/// </summary>
+		private const bool _isPublicApi = true;
+
+
+		protected ICoinGeckoClient GetClient()
+		{
+			if (string.IsNullOrEmpty(_apiKey))
+			{
+				return CoinGeckoClient.Instance;
+			}
+			else
+			{
+				return new CoinGeckoClient(new HttpClient(new HttpClientHandler()), new JsonSerializerSettings(), _apiKey, _isPublicApi);
+			}
+		}
+
+	}
+}

--- a/CoinGecko.Test/CoinsClientTests.cs
+++ b/CoinGecko.Test/CoinsClientTests.cs
@@ -10,18 +10,18 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class CoinsClientTests
+    public class CoinsClientTests: TestBase
     {
         private readonly Task<Entities.Response.Coins.CoinFullDataById> _allCoinDataBitCoin;
         private readonly Task<Entities.Response.Coins.CoinFullDataById> _allCoinDataBitCoinWithParameter;
         public CoinsClientTests()
         {
-            _client = CoinGeckoClient.Instance;
+	        _client = GetClient();
             _allCoinDataBitCoin = GetAllCoinDataForBtc();
             _allCoinDataBitCoinWithParameter = GetAllCoinDataWithParameterForBtc();
         }
 
-        
+
         private readonly ICoinGeckoClient _client;
 
         private async Task<CoinFullDataById> GetAllCoinDataForBtc()
@@ -133,6 +133,7 @@ namespace CoinGecko.Test
         [Fact]
         public async Task Bitcoin_Market_Chart_Price_Lenght_Must_Equal_to_Marketcaps_Lenght()
         {
+	        await Task.Delay(300);
             var result = await _client.CoinsClient.GetMarketChartsByCoinId("bitcoin", "usd", "max");
             Assert.Equal(result.Prices.Length, result.MarketCaps.Length);
         }

--- a/CoinGecko.Test/ContractClientTests.cs
+++ b/CoinGecko.Test/ContractClientTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class ContractClientTests
+    public class ContractClientTests: TestBase
     {
         private readonly ICoinGeckoClient _client;
 
         public ContractClientTests()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+           _client = GetClient();
+		}
 
         [Fact]
         public async Task Get_Contract_Data_for_Eth_Bat()

--- a/CoinGecko.Test/DerivativesClientTests.cs
+++ b/CoinGecko.Test/DerivativesClientTests.cs
@@ -7,14 +7,14 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class DerivativesClientTests
+    public class DerivativesClientTests:TestBase
     {
         private readonly ICoinGeckoClient _client;
 
         public DerivativesClientTests()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+	        _client = GetClient();
+		}
 
         [Fact]
         public async Task Derivatives_Count_Not_Equal_Zero()

--- a/CoinGecko.Test/EventsClientTests.cs
+++ b/CoinGecko.Test/EventsClientTests.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class EventsClientTests
+    public class EventsClientTests:TestBase
     {
         private readonly ICoinGeckoClient _client;
 
         public EventsClientTests()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+	        _client = GetClient();
+		}
 
         [Fact]
         public async Task Events_Count_Equal_to_Data_Length()

--- a/CoinGecko.Test/ExchangeRatesClientTests.cs
+++ b/CoinGecko.Test/ExchangeRatesClientTests.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class ExchangeRatesClientTests
+    public class ExchangeRatesClientTests: TestBase
     {
         private readonly ICoinGeckoClient _client;
 
         public ExchangeRatesClientTests()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+            _client = GetClient();
+		}
 
         [Fact]
         public async Task Exchange_Rates_Cointains_Eos()

--- a/CoinGecko.Test/ExchangesClientTests.cs
+++ b/CoinGecko.Test/ExchangesClientTests.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class ExchangesClientTests
+    public class ExchangesClientTests: TestBase
     {
         private readonly ICoinGeckoClient _client;
 
         public ExchangesClientTests()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+			_client = GetClient();
+		}
 
         [Fact]
         public async Task Exchanges_Count_Not_Equal_to_Zero()

--- a/CoinGecko.Test/GlobalClientTests.cs
+++ b/CoinGecko.Test/GlobalClientTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class GlobalClientTests
+    public class GlobalClientTests: TestBase
     {
         private readonly ICoinGeckoClient _client;
 
         public GlobalClientTests()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+	        _client = GetClient();
+		}
 
         [Fact]
         public async Task Global_Data_Must_Not_Null()

--- a/CoinGecko.Test/IndexesClientTest.cs
+++ b/CoinGecko.Test/IndexesClientTest.cs
@@ -5,13 +5,13 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class IndexesClientTest
+    public class IndexesClientTest: TestBase
     {
         private readonly ICoinGeckoClient _client;
         public IndexesClientTest()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+			_client = GetClient();
+		}
 
         [Fact]
         public async Task Indexes_Count_Not_Equal_Zero()

--- a/CoinGecko.Test/PingClientTests.cs
+++ b/CoinGecko.Test/PingClientTests.cs
@@ -5,13 +5,13 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class PingClientTests
+    public class PingClientTests: TestBase
     {
         private readonly ICoinGeckoClient _client;
         public PingClientTests()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+			_client = GetClient();
+		}
         [Fact]
         public async Task Ping_Method_Must_Return_ToTheMoon()
         {

--- a/CoinGecko.Test/SearchClientTests.cs
+++ b/CoinGecko.Test/SearchClientTests.cs
@@ -5,14 +5,14 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class SearchClientTests
+    public class SearchClientTests: TestBase
     {
         private readonly ICoinGeckoClient _client;
 
         public SearchClientTests()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+			_client = GetClient();
+		}
 
         [Fact]
         public async Task SearchTrending_TrendingItems_Fields_Not_Null()

--- a/CoinGecko.Test/SimpleClientTests.cs
+++ b/CoinGecko.Test/SimpleClientTests.cs
@@ -5,13 +5,13 @@ using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class SimpleClientTests
+    public class SimpleClientTests: TestBase
     {
         private readonly ICoinGeckoClient _client;
         public SimpleClientTests()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+			_client = GetClient();
+		}
         [Fact]
         public async Task BTC_To_ETH_Convert_Must_Not_Null()
         {

--- a/CoinGecko.Test/StatusUpdatesClientTest.cs
+++ b/CoinGecko.Test/StatusUpdatesClientTest.cs
@@ -1,22 +1,18 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
+﻿using System.Linq;
 using System.Threading.Tasks;
-using CoinGecko.Clients;
 using CoinGecko.Interfaces;
-using CoinGecko.Parameters;
 using Xunit;
 
 namespace CoinGecko.Test
 {
-    public class StatusUpdatesClientTest
+    public class StatusUpdatesClientTest: TestBase
     {
         private readonly ICoinGeckoClient _client;
         
         public StatusUpdatesClientTest()
         {
-            _client = CoinGeckoClient.Instance;
-        }
+	        _client = GetClient();
+		}
 
         [Theory]
         [InlineData("general")]

--- a/CoinGecko/Clients/BaseApiClient.cs
+++ b/CoinGecko/Clients/BaseApiClient.cs
@@ -56,7 +56,7 @@ namespace CoinGecko.Clients
 		        }
 		        else
 		        {
-			        resourceUri = AddParameter(resourceUri, "x-cg-demo-api-key", _apiKey);
+			        resourceUri = AddParameter(resourceUri, "x_cg_demo_api_key", _apiKey);
 		        }
 	        }
 

--- a/CoinGecko/Clients/BaseApiClient.cs
+++ b/CoinGecko/Clients/BaseApiClient.cs
@@ -17,12 +17,22 @@ namespace CoinGecko.Clients
         private readonly HttpClient _httpClient;
         private readonly JsonSerializerSettings _serializerSettings;
         private readonly string _apiKey;
+        private readonly bool _isProMode = false;
 
-        public BaseApiClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey)
+        public BaseApiClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced = false)
         {
             _httpClient = httpClient;
             _serializerSettings = serializerSettings;
             _apiKey = apiKey;
+
+            if (isPublicApiForced)
+            {
+	            _isProMode = false;
+            }
+            else if(!string.IsNullOrEmpty(apiKey))
+            {
+	            _isProMode = true;
+            }
         }
 
         public BaseApiClient(HttpClient httpClient, JsonSerializerSettings serializerSettings)
@@ -33,12 +43,19 @@ namespace CoinGecko.Clients
 
         public async Task<T> GetAsync<T>(Uri resourceUri)
         {
-            if (!string.IsNullOrEmpty(_apiKey))
-            {
-                resourceUri = AddParameter(resourceUri, "x_cg_pro_api_key", _apiKey);
-            }
+	        if (!string.IsNullOrEmpty(_apiKey))
+	        {
+		        if (_isProMode)
+		        {
+			        resourceUri = AddParameter(resourceUri, "x_cg_pro_api_key", _apiKey);
+		        }
+		        else
+		        {
+			        resourceUri = AddParameter(resourceUri, "x-cg-demo-api-key", _apiKey);
+		        }
+	        }
 
-            //_httpClient.DefaultRequestHeaders.Add("User-Agent", "your bot 0.1");
+	        _httpClient.DefaultRequestHeaders.Add("User-Agent", "your bot 0.1");
             var response = await _httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, resourceUri))
                 .ConfigureAwait(false);
 
@@ -93,8 +110,8 @@ namespace CoinGecko.Clients
                 .ToArray();
             var url = encodedParams.Length > 0 ? $"{path}{string.Join(string.Empty, encodedParams)}" : path;
 
-            //using pro API url if apiKey is set
-            return new Uri(string.IsNullOrEmpty(_apiKey) ? BaseApiEndPointUrl.ApiEndPoint : BaseApiEndPointUrl.ProApiEndPoint, url);
+            //using pro API url if apiKey is set and public mode not forced
+            return new Uri(_isProMode ? BaseApiEndPointUrl.ProApiEndPoint : BaseApiEndPointUrl.ApiEndPoint, url);
         }
     }
 }

--- a/CoinGecko/Clients/BaseApiClient.cs
+++ b/CoinGecko/Clients/BaseApiClient.cs
@@ -17,9 +17,9 @@ namespace CoinGecko.Clients
         private readonly HttpClient _httpClient;
         private readonly JsonSerializerSettings _serializerSettings;
         private readonly string _apiKey;
-        private readonly bool _isProMode = false;
+        private readonly bool _isProMode;
 
-        public BaseApiClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced = false)
+        public BaseApiClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced)
         {
             _httpClient = httpClient;
             _serializerSettings = serializerSettings;

--- a/CoinGecko/Clients/BaseApiClient.cs
+++ b/CoinGecko/Clients/BaseApiClient.cs
@@ -35,7 +35,12 @@ namespace CoinGecko.Clients
             }
         }
 
-        public BaseApiClient(HttpClient httpClient, JsonSerializerSettings serializerSettings)
+        public BaseApiClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey): this(httpClient, serializerSettings, apiKey, false)
+        {
+        }
+
+
+		public BaseApiClient(HttpClient httpClient, JsonSerializerSettings serializerSettings)
         {
             _httpClient = httpClient;
             _serializerSettings = serializerSettings;

--- a/CoinGecko/Clients/CoinGeckoClient.cs
+++ b/CoinGecko/Clients/CoinGeckoClient.cs
@@ -15,12 +15,13 @@ namespace CoinGecko.Clients
         private bool _isDisposed;
         private readonly JsonSerializerSettings _serializerSettings;
         private readonly string _apiKey;
+        private readonly bool _isPublicApiForced;
 
-        #endregion Fields
+		#endregion Fields
 
-        #region Constructors
+		#region Constructors
 
-        public CoinGeckoClient() : this((JsonSerializerSettings)null)
+		public CoinGeckoClient() : this((JsonSerializerSettings)null)
         {
         }
 
@@ -81,25 +82,34 @@ namespace CoinGecko.Clients
             _apiKey = apiKey;
         }
 
-        #endregion Constructors
+        public CoinGeckoClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced)
+        {
+	        _httpClient = httpClient;
+	        _serializerSettings = serializerSettings;
+	        _apiKey = apiKey;
+	        _isPublicApiForced = isPublicApiForced;
 
-        #region Properties
+        }
 
-        public static CoinGeckoClient Instance => Lazy.Value;
+		#endregion Constructors
 
-        public ISimpleClient SimpleClient => new SimpleClient(_httpClient, _serializerSettings, _apiKey);
-        public IPingClient PingClient => new PingClient(_httpClient, _serializerSettings, _apiKey);
-        public ICoinsClient CoinsClient => new CoinsClient(_httpClient, _serializerSettings, _apiKey);
-        public IExchangesClient ExchangesClient => new ExchangesClient(_httpClient, _serializerSettings, _apiKey);
-        public IEventsClient EventsClient => new EventsClient(_httpClient, _serializerSettings, _apiKey);
-        public IExchangeRatesClient ExchangeRatesClient => new ExchangeRatesClient(_httpClient, _serializerSettings, _apiKey);
-        public IGlobalClient GlobalClient => new GlobalClient(_httpClient, _serializerSettings, _apiKey);
-        public IContractClient ContractClient => new ContractClient(_httpClient, _serializerSettings, _apiKey);
-        public IFinancePlatformsClient FinancePlatformsClient => new FinancePlatformsClient(_httpClient, _serializerSettings, _apiKey);
-        public IIndexesClient IndexesClient => new IndexesClient(_httpClient, _serializerSettings, _apiKey);
-        public IDerivativesClient DerivativesClient => new DerivativesClient(_httpClient, _serializerSettings, _apiKey);
-        public IStatusUpdatesClient StatusUpdatesClient => new StatusUpdateClient(_httpClient, _serializerSettings, _apiKey);
-        public ISearchClient SearchClient => new SearchClient(_httpClient, _serializerSettings, _apiKey);
+		#region Properties
+
+		public static CoinGeckoClient Instance => Lazy.Value;
+
+        public ISimpleClient SimpleClient => new SimpleClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IPingClient PingClient => new PingClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public ICoinsClient CoinsClient => new CoinsClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IExchangesClient ExchangesClient => new ExchangesClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IEventsClient EventsClient => new EventsClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IExchangeRatesClient ExchangeRatesClient => new ExchangeRatesClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IGlobalClient GlobalClient => new GlobalClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IContractClient ContractClient => new ContractClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IFinancePlatformsClient FinancePlatformsClient => new FinancePlatformsClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IIndexesClient IndexesClient => new IndexesClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IDerivativesClient DerivativesClient => new DerivativesClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public IStatusUpdatesClient StatusUpdatesClient => new StatusUpdateClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
+        public ISearchClient SearchClient => new SearchClient(_httpClient, _serializerSettings, _apiKey, _isPublicApiForced);
 
         #endregion Properties
 

--- a/CoinGecko/Clients/CoinsClient.cs
+++ b/CoinGecko/Clients/CoinsClient.cs
@@ -19,7 +19,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<IReadOnlyList<CoinFullData>> GetAllCoinsData()
+        public CoinsClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<IReadOnlyList<CoinFullData>> GetAllCoinsData()
         {
             return await GetAllCoinsData(OrderField.GeckoDesc, null, null, "", null).ConfigureAwait(false);
         }

--- a/CoinGecko/Clients/ContractClient.cs
+++ b/CoinGecko/Clients/ContractClient.cs
@@ -18,7 +18,13 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<ContractData> GetContractData(string id, string contractAddress)
+        public ContractClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+
+        }
+
+		public async Task<ContractData> GetContractData(string id, string contractAddress)
         {
             return await GetAsync<ContractData>(AppendQueryString(
                 ContractApiEndPoints.ContractDetailAddress(id, contractAddress)))

--- a/CoinGecko/Clients/DerivativesClient.cs
+++ b/CoinGecko/Clients/DerivativesClient.cs
@@ -19,8 +19,12 @@ namespace CoinGecko.Clients
         {
         }
 
+        public DerivativesClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
 
-        public async Task<IReadOnlyList<Derivatives>> GetDerivatives()
+		public async Task<IReadOnlyList<Derivatives>> GetDerivatives()
         {
             return await GetDerivatives("").ConfigureAwait(false);
         }

--- a/CoinGecko/Clients/EventsClient.cs
+++ b/CoinGecko/Clients/EventsClient.cs
@@ -18,7 +18,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<Events> GetEvents()
+        public EventsClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<Events> GetEvents()
         {
             return await GetEvents(new string[] { }, new string[] { }, null, null, null, null).ConfigureAwait(false);
         }

--- a/CoinGecko/Clients/ExchangeRatesClient.cs
+++ b/CoinGecko/Clients/ExchangeRatesClient.cs
@@ -17,7 +17,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<ExchangeRates> GetExchangeRates()
+        public ExchangeRatesClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<ExchangeRates> GetExchangeRates()
         {
             return await GetAsync<ExchangeRates>(
                 AppendQueryString(ExchangeRatesApiEndPoints.ExchangeRate)).ConfigureAwait(false);

--- a/CoinGecko/Clients/ExchangesClient.cs
+++ b/CoinGecko/Clients/ExchangesClient.cs
@@ -18,7 +18,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<IReadOnlyList<Exchanges>> GetExchanges()
+        public ExchangesClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<IReadOnlyList<Exchanges>> GetExchanges()
         {
             return await GetExchanges(100, "").ConfigureAwait(false);
         }

--- a/CoinGecko/Clients/FinancePlatformsClient.cs
+++ b/CoinGecko/Clients/FinancePlatformsClient.cs
@@ -18,7 +18,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<IReadOnlyList<FinancePlatforms>> GetFinancePlatforms()
+        public FinancePlatformsClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<IReadOnlyList<FinancePlatforms>> GetFinancePlatforms()
         {
             return await GetFinancePlatforms(50, "100").ConfigureAwait(false);
         }

--- a/CoinGecko/Clients/GlobalClient.cs
+++ b/CoinGecko/Clients/GlobalClient.cs
@@ -17,7 +17,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<Global> GetGlobal()
+        public GlobalClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<Global> GetGlobal()
         {
             return await GetAsync<Global>(AppendQueryString(GlobalApiEndPoints.Global)).ConfigureAwait(false);
         }

--- a/CoinGecko/Clients/IndexesClient.cs
+++ b/CoinGecko/Clients/IndexesClient.cs
@@ -18,7 +18,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<IReadOnlyList<IndexData>> GetIndexes()
+        public IndexesClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<IReadOnlyList<IndexData>> GetIndexes()
         {
             return await GetIndexes(null, "").ConfigureAwait(false);
         }

--- a/CoinGecko/Clients/PingClient.cs
+++ b/CoinGecko/Clients/PingClient.cs
@@ -16,7 +16,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<Ping> GetPingAsync()
+        public PingClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<Ping> GetPingAsync()
         {
             return await GetAsync<Ping>(AppendQueryString("ping")).ConfigureAwait(false);
         }

--- a/CoinGecko/Clients/SearchClient.cs
+++ b/CoinGecko/Clients/SearchClient.cs
@@ -17,7 +17,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<TrendingList> GetSearchTrending()
+        public SearchClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<TrendingList> GetSearchTrending()
         {
             return await GetAsync<TrendingList>(
                  AppendQueryString(SearchApiEndpoints.SearchTrending))

--- a/CoinGecko/Clients/SimpleClient.cs
+++ b/CoinGecko/Clients/SimpleClient.cs
@@ -18,7 +18,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<Price> GetSimplePrice(string[] ids, string[] vsCurrencies)
+        public SimpleClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<Price> GetSimplePrice(string[] ids, string[] vsCurrencies)
         {
             return await GetSimplePrice(ids, vsCurrencies, false, false, false, false).ConfigureAwait(false);
         }

--- a/CoinGecko/Clients/StatusUpdateClient.cs
+++ b/CoinGecko/Clients/StatusUpdateClient.cs
@@ -18,7 +18,12 @@ namespace CoinGecko.Clients
         {
         }
 
-        public async Task<StatusUpdate> GetStatusUpdate()
+        public StatusUpdateClient(HttpClient httpClient, JsonSerializerSettings serializerSettings, string apiKey, bool isPublicApiForced) : base(httpClient,
+	        serializerSettings, apiKey, isPublicApiForced)
+        {
+        }
+
+		public async Task<StatusUpdate> GetStatusUpdate()
         {
             return await GetStatusUpdate("", "", null, null).ConfigureAwait(false);
         }

--- a/CoinGecko/CoinGecko.csproj
+++ b/CoinGecko/CoinGecko.csproj
@@ -21,7 +21,7 @@
         <PackageReleaseNotes>
             Coin Gecko Api wrapper written in .net standard 2.0 for more information please check the official documentation from https://www.coingecko.com/api/docs/v3
         </PackageReleaseNotes>
-        <Version>1.6.0</Version>
+        <Version>1.6.1</Version>
     </PropertyGroup>
 
     <ItemGroup>


### PR DESCRIPTION
Currently there is a "demo" subscription on coingecko, which allows limited access to public api. 

Current constructors of CoinGeckoClient are forcing to use "pro" api, hence - does not support "demo" keys. 

This is the fix for such behavior, allowing library consumer to propagate "isPublicApiForced" flag to constructor and use "demo" subscription key with public api.