### PR TITLE
fix: removed tolower call on all query string value

### DIFF
--- a/CoinGecko/Clients/BaseApiClient.cs
+++ b/CoinGecko/Clients/BaseApiClient.cs
@@ -105,7 +105,7 @@ namespace CoinGecko.Clients
             {
                 urlParameters.Add(par.Value == null || string.IsNullOrWhiteSpace(par.Value.ToString())
                     ? null
-                    : $"{par.Key}={par.Value.ToString().ToLower(CultureInfo.InvariantCulture)}");
+                    : $"{par.Key}={par.Value}");
             }
 
             var encodedParams = urlParameters


### PR DESCRIPTION
.ToLower() executed on every QueryString value of every request makes requests like follows:
`coinGeckoClient.SimpleClient.GetTokenPrice(solanaId, tokensAddresses.ToArray(), new[] { "USD" });`

To fail due to case-sensitive token addresses on Solana platform.

Moreover, I don't see any reason to call "ToLower()" for any string parameter value.